### PR TITLE
EIP-2930: Updates transaction format to match EIP-2718

### DIFF
--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -16,7 +16,7 @@ Adds a transaction type which contains an access list, a list of addresses and s
 
 ## Abstract
 
-We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `rlp([3, [nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`.
+We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `3 || rlp([nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS])`.
 
 The `access_list` specifies a list of addresses and storage keys; these addresses and storage keys are added into the `accessed_addresses` and `accessed_storage_keys` global sets (introduced in [EIP-2929](./eip-2929.md)). A gas cost is charged, though at a discount relative to the cost of accessing outside the list.
 


### PR DESCRIPTION
2718 has the first byte of every transaction be the transaction type, and the remaining bytes are interpreted however this EIP wants.  This is the minimal change required to get it in line with 2718 so I think we should merge this ASAP and then continue discussion on whether we think this is the optimal format or not.