### PR TITLE
Update EIP-4788: Move to Prime Modulus

### DIFF
--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -29,7 +29,7 @@ restaking constructions, smart contract bridges, MEV mitigations and more.
 | constants                    | value                                        |
 |---                           |---                                           |
 | `FORK_TIMESTAMP`             | TBD                                          |
-| `HISTORY_BUFFER_LENGTH`      | `93600`                                      |
+| `HISTORY_BUFFER_LENGTH`      | `8191`                                      |
 | `SYSTEM_ADDRESS`             | `0xfffffffffffffffffffffffffffffffffffffffe` |
 | `BEACON_ROOTS_ADDRESS`       | `0xBEaC020001c6C8B69E5257f4754e46e25f5dc9cB` |
 


### PR DESCRIPTION
See https://github.com/ethereum/EIPs/pull/7672#issuecomment-1714588961.

`HISTORY_BUFFER_LENGTH` determines the overall size of the history region of the 4788 contract in storage. Both current proposed modulus, as well as the replacement proposed in the branch this PR is against, share prime factors with the current slot time (12s). This means that the usage of the history region will be sparse (only 1/12 of the storage slots in the region will be used). Furthermore, if we change the slot time in the future, this will change in somewhat arbitrary ways (depending on how many factors the new slot time and the modulus share). While this does not affect the functioning of the EIP, it does add unnecessary variance to two aspects, namely the total storage requirements and the total history depth available.

This PR changes the modulus to a prime number, so that there can never be any shared factors with the slot time. This way, 100% of the history region will be utilized, allowing for simple reasoning about total storage requirements and the total history depth, even in the case of future slot time changes. The specific value (`8191 == 2**13 - 1`) was chosen so that in the 12s slot time case it matches the total history depth of the original modulus as closely as possible.