### PR TITLE
clarifies direction of communication, illustrates with block encoding

### DIFF
--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -12,7 +12,7 @@ created: 2024-04-14
 
 ## Abstract
 
-This proposal defines a general purpose framework for propagating contract-triggered requests from execution layer to the consensus layer. It extends the header and body with only a single field each to store the request information.
+This proposal defines a general purpose framework for propagating contract-triggered requests from execution layer to the consensus layer, via proposed blocks. It extends the header and body with only a single field each to store the request information, using the block itself as a communication channel to the consensus layer.
 
 ## Motivation
 
@@ -22,27 +22,60 @@ The proliferation of smart contract controlled validators has caused there to be
 
 ### Execution Layer
 
-#### Request
+#### Constants
 
-A `Request` consists of a `RequestType` prepended to an opaque byte array `RequestData`.
+| Name | Value | Comment |
+| - | - | - |
+|`FORK_TIMESTAMP` | *TBD* | Mainnet |
+
+#### Definitions
+
+* **`FORK_BLOCK`** -- the first block in a blockchain with the `timestamp` greater or equal to `FORK_TIMESTAMP`.
+* **`request`** -- A `request` consists of a `request_type` prepended to an opaque byte array `request_data`:
 
 ```
-Request = RequestType ++ RequestData
+request = request_type ++ request_data
 ```
 
-Let `Requests` be the list of all `Request` objects in the block in ascending order by type.
+Let `requests` be the list of all `request` objects in the block in ascending order by type.
 
-#### Header
+#### Block structure
 
-Extend the header with a new 32 byte value `RequestsRoot`.
+Beginning with the `FORK_BLOCK`, the block body **MUST** be appended with a list of requests. RLP encoding of an extended block body structure **MUST** be computed as follows:
 
-Let `RequestsRoot` be the root of a Merkle-Patricia trie keyed by the index in the list of `Requests`. This is equivalent to how the transaction trie root is computed.
+```python
+block_body_rlp = RLP([
+    field_0,
+    ...,
+    # Latest block body field before `requests`
+    field_n,
+
+    [request_0, ..., request_k],
+])
+```
+
+#### Block Header
+
+Extend the header with a new 32 byte value `requests_root`.
+
+Let `requests_root` be the root of a Merkle-Patricia trie keyed by the index in the list of `requests`. This is equivalent to how the transaction trie root is computed.
+
+Beginning with the `FORK_BLOCK`, the block header **MUST** be appended with the new **`requests_root`** field. The value of this field is the trie root committing to the `requests` in the block body. **`requests_root`** field value **MUST** be computed as follows:
+
+```python
+def compute_trie_root_from_indexed_data(data):
+    trie = Trie.from([(i, obj) for i, obj in enumerate(data)])
+    return trie.root
+
+block.header.requests_root = compute_trie_root_from_indexed_data(block.body.requests)
+```
+
 
 ### Consensus Layer
 
 Each proposal may choose how to extend `ExecutionPayload` to include the new EL request.
 
-A additional processing step is be added to `process_execution_payload` to iterate over and process all requests.
+A additional processing step is to be added to `process_execution_payload` to iterate over and process all requests.
 
 ## Rationale
 


### PR DESCRIPTION
Only added a few clarifying sentences, but i think the real lift is including the block serialization specs. This makes it pretty clear how 6110 and 7002 could be slipped in here.