### PR TITLE
Update EIP-8141: charge calldata floor on serialized bytes

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -163,7 +163,6 @@ for sig in tx.signatures:
         invalid_transaction()
 
 total_frame_gas = 0
-total_frame_execution_gas = 0
 for i, frame in enumerate(tx.frames):
     assert frame.mode < 3
     assert frame.flags < 8
@@ -171,7 +170,6 @@ for i, frame in enumerate(tx.frames):
     assert frame.state_gas_limit <= 2**64 - 1
     assert frame.value < 2**256
     assert frame.mode == SENDER or frame.value == 0
-    total_frame_execution_gas += frame.execution_gas_limit
     total_frame_gas += frame.execution_gas_limit + frame.state_gas_limit
     assert total_frame_gas <= 2**64 - 1
 
@@ -186,11 +184,8 @@ for i, frame in enumerate(tx.frames):
         assert i + 1 < len(tx.frames)            # must not be last frame
         assert tx.frames[i + 1].mode != VERIFY   # batches never contain VERIFY frames
 
-# Intrinsic gas must fit the EIP-7825 transaction cap.
-assert max(
-    frame_tx_intrinsic_gas + total_frame_execution_gas,
-    calldata_floor_gas,
-) <= TX_MAX_GAS_LIMIT
+# The worst-case execution-dimension charge must fit the EIP-7825 transaction cap.
+assert execution_reservation <= TX_MAX_GAS_LIMIT
 ```
 
 #### Transaction Signatures
@@ -474,29 +469,55 @@ frame_tx_intrinsic_gas = (
     + value_transfer_cost
 )
 
-standard_gas_limit = (
-    frame_tx_intrinsic_gas
-    + sum(frame.execution_gas_limit for frame in tx.frames)
-    + sum(frame.state_gas_limit for frame in tx.frames)
-)
+# The transaction's canonical serialization, as included in a block.
+# Unlike the signature hash, no signature bytes are elided.
+tx_serialized = bytes([FRAME_TX_TYPE]) + rlp(tx)
 
-calldata_tokens = (
-    sum(tokens_in(frame.data) for frame in tx.frames)
-    + sum(tokens_in(sig.signer) + tokens_in(sig.msg) + tokens_in(sig.signature) for sig in tx.signatures)
-)
+frame_floor_gas = [
+    FRAME_TX_PER_FRAME_COST
+    + value_cost(frame)
+    + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in(rlp(frame))
+    for frame in tx.frames
+]
 
-calldata_floor_gas = (
+shared_floor_gas = (
     FRAME_TX_INTRINSIC_COST
-    + len(tx.frames) * FRAME_TX_PER_FRAME_COST
     + signature_verification_cost
-    + value_transfer_cost
-    + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens
+    + TOTAL_COST_FLOOR_PER_TOKEN
+    * (tokens_in(tx_serialized) - sum(tokens_in(rlp(frame)) for frame in tx.frames))
 )
 
-max_gas = max(standard_gas_limit, calldata_floor_gas)
+calldata_floor_gas = shared_floor_gas + sum(frame_floor_gas)
+
+shared_standard_gas = (
+    FRAME_TX_INTRINSIC_COST
+    + signature_data_cost
+    + signature_verification_cost
+)
+
+def frame_standard_gas(frame, execution_gas, state_gas):
+    return (
+        FRAME_TX_PER_FRAME_COST
+        + value_cost(frame)
+        + calldata_cost(frame.data)
+        + execution_gas
+        + state_gas
+    )
+
+max_gas = (
+    max(shared_standard_gas, shared_floor_gas)
+    + sum(
+        max(frame_standard_gas(frame, frame.execution_gas_limit, frame.state_gas_limit), frame_floor_gas[i])
+        for i, frame in enumerate(tx.frames)
+    )
+)
 ```
 
 `frame_tx_intrinsic_gas` is the transaction's intrinsic cost in the sense of [EIP-2780](./eip-2780.md). It is derivable from from the transaction fields alone, with no state access. It is charged entirely in the execution dimension and, together with the sum of the declared frame execution-gas limits, is limited by the [EIP-7825](./eip-7825.md) cap explained in [Constraints](#constraints). `value_transfer_cost` charges `TX_VALUE_COST` for each frame which carries value, covering the recipient balance write and transfer log exactly as EIP-2780 prices top-level value transfers. State dependent costs do not enter this calculation and are charged at runtime inside frame state-gas budgets, as described below.
+
+The floor is charged on the full serialized transaction, not only on `data` and signature bytes. Fields like `target`, `value`, the gas limits, `blob_versioned_hashes` and the RLP structure itself all end up as bytes in the block, so they pay the same [EIP-7623](./eip-7623.md) floor rate as calldata. `tx_serialized` is the transaction as it appears in a block; the [EIP-7594](./eip-7594.md) networking wrapper for blobs is not part of it. The floor still depends only on the transaction fields and needs no state access.
+
+The floor is also split per frame, like the gas pools: each frame's floor covers its own serialized bytes, and the shared part (the outer fields and the signatures) covers the rest. At settlement each part pays the larger of what it used and its own floor, so one frame's execution cannot cover another frame's bytes. The standard parts add up exactly to `frame_tx_intrinsic_gas` plus the frame usage, so a frame with enough execution pays the same as before. The shared part carries no execution of its own beyond signature verification, so in practice it always pays its floor.
 
 ###### Frame gas pools
 
@@ -543,7 +564,7 @@ In both cases the storage slot's ownership entry is cleared, so a subsequent cre
 All changes to `state_gas_left`, outstanding charge ownership, and frame receipts' `state_gas_used` fields are journaled at the same rollback boundaries as the associated state changes:
 
 - When an EVM call frame reverts or halts exceptionally, restore the state-gas journal and the active frame's `state_gas_left` to the checkpoint covering that call and any associated pre-call state charge.
-- When a frame reverts, restore the journal and `state_gas_left` to frame entry. Its final `state_gas_used` is therefore zero, and any changes it made to earlier receipts are undone. Both remaining pools count toward `tx_unused_gas`.
+- When a frame reverts, restore the journal and `state_gas_left` to frame entry. Its final `state_gas_used` is therefore zero, and any changes it made to earlier receipts are undone. Neither remaining pool is charged at settlement.
 - When a frame halts exceptionally, perform the same state-gas restoration, but consume its entire execution-gas pool. Its final `state_gas_used` is zero.
 - When an atomic batch is unrolled, restore the state-gas journal to the batch-entry checkpoint. Charges attributed to frames in the batch are removed from their receipts, while refills of charges attributed to frames before the batch are undone. Closed frame pools are not reopened.
 
@@ -557,29 +578,32 @@ Each frame's receipt reports its execution-gas usage measured at frame exit:
 frame_receipt.execution_gas_used = frame.execution_gas_limit - gas_left
 ```
 
-At frame exit, `frame_receipt.state_gas_used` equals `frame.state_gas_limit - state_gas_left`. It remains subject to journaled changes caused by later frames. After all frames and atomic rollbacks have completed, it is the frame's final attributed state gas. The sum of frame execution and state usage does not generally equal the transaction's `gas_used`: intrinsic costs are charged outside frame budgets, while the storage refund and calldata floor apply at the transaction level.
+At frame exit, `frame_receipt.state_gas_used` equals `frame.state_gas_limit - state_gas_left`. It remains subject to journaled changes caused by later frames. After all frames and atomic rollbacks have completed, it is the frame's final attributed state gas. The sum of frame execution and state usage does not generally equal the transaction's `gas_used`: intrinsic costs are charged outside frame budgets, the storage refund applies at the transaction level, and each frame settles against its own calldata floor.
 
-Gas not charged at settlement includes execution and state gas left in frame pools at frame exit, skipped-frame budgets, and state gas removed from a receipt by a later refill or rollback. None of this gas becomes available to a subsequent frame. Let `frame_receipts` be the ordered frame receipt list. After all frames, the total amount not charged can be calculated as:
+Gas not charged at settlement includes execution and state gas left in frame pools at frame exit, skipped-frame budgets, and state gas removed from a receipt by a later refill or rollback. None of this gas becomes available to a subsequent frame. Settlement charges each part for what it used, never for its declared limits. Let `frame_receipts` be the ordered frame receipt list.
+
+Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. State-gas refills have already reduced the owning frame receipts before settlement. At the end of the transaction, each frame pays the larger of what it used and its own floor, the shared part does the same, and the storage refund and EIP-7623 rules apply on top:
 
 ```python
-tx_unused_gas = sum(
-    (frame.execution_gas_limit - frame_receipt.execution_gas_used)
-    + (frame.state_gas_limit - frame_receipt.state_gas_used)
-    for frame, frame_receipt in zip(tx.frames, frame_receipts)
+gas_used_before_refund = (
+    max(shared_standard_gas, shared_floor_gas)
+    + sum(
+        max(
+            frame_standard_gas(frame, frame_receipt.execution_gas_used, frame_receipt.state_gas_used),
+            frame_floor_gas[i],
+        )
+        for i, (frame, frame_receipt) in enumerate(zip(tx.frames, frame_receipts))
+    )
 )
-```
-
-Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. State-gas refills have already reduced the owning frame receipts before settlement. At the end of the transaction, apply the storage refund and EIP-7623 rules to get the final `gas_used` value:
-
-```python
-gas_used_before_refund = standard_gas_limit - tx_unused_gas
 applied_refund = min(refund_counter, gas_used_before_refund // MAX_REFUND_QUOTIENT)
 gas_used_after_refund = gas_used_before_refund - applied_refund
 
 gas_used = max(gas_used_after_refund, calldata_floor_gas)
 ```
 
-Because a state-gas refill directly reduces `frame_receipt.state_gas_used`, it reduces `gas_used_before_refund` and is not subject to the refund cap. Per EIP-8037, a refill reverses a charge for state that was never durably created, while a refund rebates work that was actually performed.
+A reverted or skipped frame still pays its floor: its bytes are part of the block regardless of the outcome.
+
+Because a state-gas refill directly reduces `frame_receipt.state_gas_used`, it reduces `gas_used_before_refund` and is not subject to the refund cap. It can never reduce a frame's charge below that frame's floor. Per EIP-8037, a refill reverses a charge for state that was never durably created, while a refund rebates work that was actually performed.
 
 The payer's refund is then computed below using the final `gas_used` value:
 
@@ -613,9 +637,12 @@ All intrinsic costs are execution gas, so the execution dimension is the transac
 A frame transaction may be included in a block only if its worst case fits the remaining capacity of **each** dimension:
 
 ```python
-execution_reservation = max(
-    frame_tx_intrinsic_gas + sum(frame.execution_gas_limit for frame in tx.frames),
-    calldata_floor_gas,
+execution_reservation = (
+    max(shared_standard_gas, shared_floor_gas)
+    + sum(
+        max(frame_standard_gas(frame, frame.execution_gas_limit, 0), frame_floor_gas[i])
+        for i, frame in enumerate(tx.frames)
+    )
 )
 state_reservation = sum(frame.state_gas_limit for frame in tx.frames)
 
@@ -623,7 +650,7 @@ assert execution_reservation <= block_gas_limit - block_output.block_execution_g
 assert state_reservation <= block_gas_limit - block_output.block_state_gas_used
 ```
 
-Because both budgets are explicit, these reservations are exact per dimension; no portion of the transaction's gas is reserved in both dimensions at once, as it must be under EIP-8037's reservoir model.
+`frame_standard_gas` is evaluated with zero state gas because state gas is reserved separately; floor excess is charged in the execution dimension. Because both budgets are explicit, these reservations are exact per dimension; no portion of the transaction's gas is reserved in both dimensions at once, as it must be under EIP-8037's reservoir model.
 
 ##### Blob handling
 
@@ -1168,9 +1195,17 @@ Value-bearing frames are charged `TX_VALUE_COST` for the recipient balance write
 
 EIP-2780's split between intrinsic and runtime gas carries over. Intrinsic gas is state-independent and decides validity. Every state-dependent charge, including frame-entry account creation and sender creation by `APPROVE`, is metered inside a frame's `state_gas_limit`. Exhausting it fails the frame. After approval the transaction is still included and pays for the gas consumed, while a failed `VERIFY` frame invalidates the transaction as usual.
 
+### Calldata floor over the serialized transaction
+
+Other transaction types have a fixed-size envelope, so a fixed base cost, 21,000 today and `TX_BASE_COST` under [EIP-2780](./eip-2780.md), can silently pay for it. The frame transaction envelope is not fixed: it can hold up to `MAX_FRAMES` frames, each with a `target`, `value` and two gas limits, plus any number of signatures. If the floor only priced `data` and signature bytes, each frame could carry roughly 60 unpriced bytes for just `FRAME_TX_PER_FRAME_COST`, about 8 gas per byte. That would let frame transactions fill blocks several times cheaper per byte than the [EIP-7623](./eip-7623.md) floor allows.
+
+Charging the floor on the serialized transaction fixes this in one step. Every byte pays the floor rate exactly once, and there is no list of fields that could miss one: a field added later is priced automatically. Compact encodings pay less, so the price follows the actual bytes on the wire. If a future scheme aggregates or elides signature bytes, those bytes disappear from the serialization and the floor drops with them. The standard side is unchanged, and the floor only binds when execution gas does not already exceed it, just like EIP-7623 treats calldata. A plain ETH transfer from a smart account (~141 bytes) becomes floor-bound at about 27,000 gas, against the 18,000 of a bare EIP-2780 transfer; the difference is the floor on its bytes, the two per-frame costs and the separately priced signature. Frames with enough execution are unaffected. A successor floor pricing such as [EIP-7976](./eip-7976.md) simply applies its rate to the same byte count.
+
+The floor is settled per frame for the same reason the gas pools are per frame: frames belong to mutually distrusting parties. With one transaction-wide floor, a bundler could place data-heavy frames next to compute-heavy frames from other users and let their execution cover its bytes, selling block space below the floor. With per-frame settlement each frame pays the larger of what it used and the floor on its own bytes, so the price of a frame does not depend on who else is in the transaction. Every frame's floor is known from the transaction alone, so a bundler or paymaster can compute each party's exact share without simulation, and the receipts need no new fields. A frame whose execution exceeds its floor pays exactly what it would pay under a transaction-wide floor.
+
 ### Transaction execution gas cap
 
-[EIP-7825](./eip-7825.md) caps the transaction's full execution budget: `frame_tx_intrinsic_gas` plus the sum of all `execution_gas_limit` values must not exceed `TX_MAX_GAS_LIMIT`, and the calldata floor is checked against the same cap. State gas is excluded, bounded only by the encoding limit and block state-gas capacity, matching EIP-8037.
+[EIP-7825](./eip-7825.md) caps the transaction's full execution budget: the worst-case execution-dimension charge, `execution_reservation`, must not exceed `TX_MAX_GAS_LIMIT`. It covers the declared execution limits and the calldata floors together. State gas is excluded, bounded only by the encoding limit and block state-gas capacity, matching EIP-8037.
 
 ### Public Key Aliases
 
@@ -1405,6 +1440,10 @@ It's recommended that to *validate* the transaction, a specific frame structure 
 For deployment of the sender account in the first frame, the mempool enforces deploy-frame determinism via the validation trace rules. Any contract may be used as `frame.target`, provided the frame's execution satisfies those rules — notably, it must not read mutable state outside `tx.sender` or maintain per-deploy factory storage (counters, reentrancy flags, etc.), so that the deployment result is independent of chain state. Factories deployed via the [EIP-7997](./eip-7997.md) deterministic factory predeploy are the canonical choice for acquiring a cross-chain-stable factory address.
 
 In general, it can be assumed that handling of frame transactions imposes similar restrictions as EIP-7702 on mempool relay, i.e. only a single transaction can be pending for an account that uses frame transactions.
+
+### Envelope Bytes and Worst-Case Block Size
+
+The floor covers the full serialization, so a frame transaction cannot buy more block bytes per gas than any other transaction type. Without this, the per-frame fields, such as a 20-byte `target` and up to 32 bytes of `value`, would only be priced through `FRAME_TX_PER_FRAME_COST`. A transaction full of maximal, empty-`data` frames would then pay about 12 gas per byte of attacker-chosen content, several times below the floor. The signature list, whose length is not otherwise bounded, has the same problem. Pricing the serialization makes the worst case independent of which fields the bytes sit in. Settling the floor per frame additionally prevents cross-subsidy inside a transaction: execution in one frame cannot cover data bytes in another, so bundled and standalone data pay the same floor.
 
 ### State Gas Isolation Between Frames
 


### PR DESCRIPTION
The calldata floor only covered data and sig bytes. The per-frame fields (target, value, gas limits) and the signature list were free at the floor: a transaction full of maximal empty-data frames paid about 12 gas per byte, multiple times below the floor.
